### PR TITLE
fix: wrap overflowed server name 

### DIFF
--- a/src/Server/Styles.module.css
+++ b/src/Server/Styles.module.css
@@ -30,9 +30,7 @@
 .ServerName {
     font-weight: 500;
     font-size: 14px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    word-break: break-word;
 }
 
 .GameInfo {


### PR DESCRIPTION
Fixes word wrapping for long server names, as it's very noticeable on mobile devices or small screens.
See before/after.

## Before:
<img width="787" alt="Screenshot 2024-08-25 at 18 13 43" src="https://github.com/user-attachments/assets/cda02268-4716-4310-8c95-ad8b1a0cdedf">

## After:
<img width="787" alt="Screenshot 2024-08-25 at 18 11 17" src="https://github.com/user-attachments/assets/8ce6bb8c-8dd1-4cba-9f2a-6b12cb740d94">

## Also works for long words:
<img width="802" alt="Screenshot 2024-08-25 at 18 15 10" src="https://github.com/user-attachments/assets/06511919-972d-42ab-9373-0a49201b6cce">